### PR TITLE
Add NewRelic Distributed Tracing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog for the gruf-newrelic gem.
 
 h3. Pending Release
+- Added ClientInterceptor with New Relic Distributed tracing support
+- Refactored ServerInterceptor with New Relic Distributed tracing support
 
 h3. 1.1.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ end
 
 This will add New Relic tracing support to all gruf controllers.
 
+### Distributed Tracing
+When controller receives gRPC request, it will automatically apply NewRelic distributed tracing information to current
+request if it is present in `newrelic` header. Make sure request has `newrelic` header with tracing payload (see below)
+and that your account and application settings have distributed tracing enabled
+
+If you are using `::Gruf::Client` to make gRPC request, you need to explicitly add NewRelic Client Interceptor
+in `client_options`:
+```ruby
+client = ::Gruf::Client.new(
+  service: ::Demo::ThingService, 
+  client_options: {
+    interceptors: [::Gruf::Newrelic::ClientInterceptor.new]
+  }
+)
+```
+
 ## License
 
 Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved 

--- a/lib/gruf/newrelic.rb
+++ b/lib/gruf/newrelic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -25,7 +27,7 @@ module Gruf
   # Newrelic gruf module
   #
   module Newrelic
-    NEWRELIC_TRACE_HEADER = "newrelic".freeze
+    NEWRELIC_TRACE_HEADER = 'newrelic'
 
     extend Configuration
   end

--- a/lib/gruf/newrelic/client_interceptor.rb
+++ b/lib/gruf/newrelic/client_interceptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/newrelic/client_interceptor.rb
+++ b/lib/gruf/newrelic/client_interceptor.rb
@@ -22,7 +22,11 @@ module Gruf
     class ClientInterceptor < ::Gruf::Interceptors::ClientInterceptor
       def call(request_context:)
         metadata = request_context.metadata
-        metadata[NEWRELIC_TRACE_HEADER] = ::NewRelic::Agent::DistributedTracing.create_distributed_trace_payload
+        payload = ::NewRelic::Agent::DistributedTracing.create_distributed_trace_payload
+
+        if payload
+          metadata[NEWRELIC_TRACE_HEADER] = payload.http_safe
+        end
 
         yield
       end

--- a/lib/gruf/newrelic/client_interceptor.rb
+++ b/lib/gruf/newrelic/client_interceptor.rb
@@ -24,9 +24,7 @@ module Gruf
         metadata = request_context.metadata
         payload = ::NewRelic::Agent::DistributedTracing.create_distributed_trace_payload
 
-        if payload
-          metadata[NEWRELIC_TRACE_HEADER] = payload.http_safe
-        end
+        metadata[NEWRELIC_TRACE_HEADER] = payload.http_safe if payload
 
         yield
       end

--- a/lib/gruf/newrelic/client_interceptor.rb
+++ b/lib/gruf/newrelic/client_interceptor.rb
@@ -12,21 +12,20 @@
 # WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-require_relative 'newrelic/version'
-require_relative 'newrelic/configuration'
-require_relative 'newrelic/server_interceptor'
-require_relative 'newrelic/client_interceptor'
+require 'new_relic/agent'
 
-##
-# Gruf main base module
 module Gruf
-  ##
-  # Newrelic gruf module
-  #
   module Newrelic
-    NEWRELIC_TRACE_HEADER = "newrelic".freeze
+    ##
+    # New Relic transaction tracing for Gruf endpoints
+    #
+    class ClientInterceptor < ::Gruf::Interceptors::ClientInterceptor
+      def call(request_context:)
+        metadata = request_context.metadata
+        metadata[NEWRELIC_TRACE_HEADER] = ::NewRelic::Agent::DistributedTracing.create_distributed_trace_payload
 
-    extend Configuration
+        yield
+      end
+    end
   end
 end

--- a/lib/gruf/newrelic/configuration.rb
+++ b/lib/gruf/newrelic/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/newrelic/server_interceptor.rb
+++ b/lib/gruf/newrelic/server_interceptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/newrelic/server_interceptor.rb
+++ b/lib/gruf/newrelic/server_interceptor.rb
@@ -13,6 +13,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 require 'new_relic/agent'
+require 'new_relic/agent/distributed_tracing'
 
 module Gruf
   module Newrelic
@@ -32,8 +33,16 @@ module Gruf
         # Yield to the given block with NewRelic tracing.
         # http://www.rubydoc.info/github/newrelic/rpm/NewRelic%2FAgent%2FInstrumentation%2FControllerInstrumentation:perform_action_with_newrelic_trace
         perform_action_with_newrelic_trace(opts) do
+          accept_distributed_tracing
           yield
         end
+      end
+
+      private
+
+      def accept_distributed_tracing
+        payload = request.active_call.metadata[NEWRELIC_TRACE_HEADER]
+        ::NewRelic::Agent::DistributedTracing.accept_distributed_trace_payload(payload)
       end
     end
   end

--- a/lib/gruf/newrelic/version.rb
+++ b/lib/gruf/newrelic/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -15,6 +17,6 @@
 #
 module Gruf
   module Newrelic
-    VERSION = '1.1.1.pre'.freeze
+    VERSION = '1.1.1.pre'
   end
 end

--- a/spec/gruf/newrelic/server_interceptor_spec.rb
+++ b/spec/gruf/newrelic/server_interceptor_spec.rb
@@ -48,5 +48,18 @@ describe Gruf::Newrelic::ServerInterceptor do
       ).once.and_yield
       subject
     end
+
+    context "distributed tracing" do
+      let(:nr_tracer) { ::NewRelic::Agent::DistributedTracing }
+      let(:nr_header_data) { 'newrelic-header-data' }
+      let(:metadata) { { Gruf::Newrelic::NEWRELIC_TRACE_HEADER => nr_header_data } }
+      let(:grpc_active_call) { double(:grpc_active_call, metadata: metadata, output_metadata: {}) }
+
+      it 'should accept nr tracing payload within newrelic trace' do
+        expect(interceptor).to receive(:perform_action_with_newrelic_trace).once.ordered.and_yield
+        expect(nr_tracer).to receive(:accept_distributed_trace_payload).with(nr_header_data).once.ordered
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
This pr introduces client and server interceptors that can pass newrelic distributed tracing payload through `newrelic` header. 