### PR TITLE
Handle the GRPC metadata properly

### DIFF
--- a/lib/gruf/newrelic/server_interceptor.rb
+++ b/lib/gruf/newrelic/server_interceptor.rb
@@ -44,7 +44,11 @@ module Gruf
 
       def accept_distributed_tracing
         payload = request.active_call.metadata[NEWRELIC_TRACE_HEADER]
-        ::NewRelic::Agent::DistributedTracing.accept_distributed_trace_payload(payload)
+        if payload.instance_of? Array
+          ::NewRelic::Agent::DistributedTracing.accept_distributed_trace_payload(payload[0])
+        else
+          ::NewRelic::Agent::DistributedTracing.accept_distributed_trace_payload(payload)
+        end
       end
     end
   end

--- a/lib/gruf/newrelic/server_interceptor.rb
+++ b/lib/gruf/newrelic/server_interceptor.rb
@@ -44,11 +44,8 @@ module Gruf
 
       def accept_distributed_tracing
         payload = request.active_call.metadata[NEWRELIC_TRACE_HEADER]
-        if payload.instance_of? Array
-          ::NewRelic::Agent::DistributedTracing.accept_distributed_trace_payload(payload[0])
-        else
-          ::NewRelic::Agent::DistributedTracing.accept_distributed_trace_payload(payload)
-        end
+        payload = payload.first if payload.is_a?(Enumerable)
+        ::NewRelic::Agent::DistributedTracing.accept_distributed_trace_payload(payload)
       end
     end
   end


### PR DESCRIPTION
Sometimes the newrelic sets multiple payloads in the header, which makes
that header an Array instead of string.