### PR TITLE
Allow customization of transaction name prefix

### DIFF
--- a/lib/gruf/newrelic/configuration.rb
+++ b/lib/gruf/newrelic/configuration.rb
@@ -22,7 +22,8 @@ module Gruf
     #
     module Configuration
       VALID_CONFIG_KEYS = {
-        server_category: :controller
+        server_category: :controller,
+        transaction_name_prefixes: []
       }.freeze
 
       attr_accessor *VALID_CONFIG_KEYS.keys

--- a/lib/gruf/newrelic/server_interceptor.rb
+++ b/lib/gruf/newrelic/server_interceptor.rb
@@ -26,9 +26,10 @@ module Gruf
       include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
       def call
+        class_name_components = Gruf::Newrelic.transaction_name_prefixes + [request.service]
         opts = {
           category: Gruf::Newrelic.server_category,
-          class_name: request.service,
+          class_name: class_name_components.join('/'),
           name: request.method_key
         }
 

--- a/spec/gruf/newrelic/configuration_spec.rb
+++ b/spec/gruf/newrelic/configuration_spec.rb
@@ -29,6 +29,7 @@ describe Gruf::Newrelic::Configuration do
     it 'should reset config vars to default' do
       obj.configure do |c|
         c.server_category = :request
+        c.transaction_name_prefixes = %w[Controller gRPC]
       end
       obj.reset
       expect(subject).to_not eq :request

--- a/spec/gruf/newrelic/server_interceptor_spec.rb
+++ b/spec/gruf/newrelic/server_interceptor_spec.rb
@@ -43,8 +43,18 @@ describe Gruf::Newrelic::ServerInterceptor do
     it 'should trace the request' do
       expect(interceptor).to receive(:perform_action_with_newrelic_trace).with(
         category: Gruf::Newrelic.server_category,
-        class_name: request.service,
+        class_name: request.service.name,
         name: request.method_key
+      ).once.and_yield
+      subject
+    end
+
+    it 'should set metric grouping' do
+      allow(Gruf::Newrelic).to receive(:transaction_name_prefixes).and_return(["Controller", "gRPC"])
+      expect(interceptor).to receive(:perform_action_with_newrelic_trace).with(
+        category: Gruf::Newrelic.server_category,
+        class_name: 'Controller/gRPC/ThingService',
+        name: 'get_thing'
       ).once.and_yield
       subject
     end


### PR DESCRIPTION
## Description:

According to the NewRelic [naming convention](https://docs.newrelic.com/docs/plugins/plugin-developer-resources/developer-reference/metric-naming-reference), we can create custom category grouping using this format: `Component/Category/Label/Units`. This will allow users to dynamically track grouped metrics in NewRelic.

For example, a [controller in Ruby](https://docs.newrelic.com/docs/using-new-relic/metrics/analyze-your-metrics/metric-timeslice-categories#Controller), might result in:

 ```
Controller/gRPC/Grpc::Health::V1::Health::Service/check
```

In this PR, we expose a configuration to customize this grouping prefix.